### PR TITLE
Added function to pull back precipitation image sequences and train a simple autoencoder model on it

### DIFF
--- a/Model.py
+++ b/Model.py
@@ -1,0 +1,53 @@
+from tensorflow.keras.layers import Input, Dense, Conv2D, MaxPooling2D, UpSampling2D
+from tensorflow.keras.models import Model
+
+def getAutoEncoder(input_shape):
+
+    # The encoding process
+    input_img = Input(shape=input_shape)  
+
+    ############
+    # Encoding #
+    ############
+
+    # Conv1 #
+    x = Conv2D(filters = 16, kernel_size = (3, 3), activation='relu', padding='same')(input_img)
+    x = MaxPooling2D(pool_size = (2, 2), padding='same')(x)
+
+    # Conv2 #
+    x = Conv2D(filters = 8, kernel_size = (3, 3), activation='relu', padding='same')(x)
+    x = MaxPooling2D(pool_size = (2, 2), padding='same')(x) 
+
+    # Conv 3 #
+    x = Conv2D(filters = 8, kernel_size = (3, 3), activation='relu', padding='same')(x)
+    encoded = MaxPooling2D(pool_size = (2, 2), padding='same')(x)
+
+    
+    
+    ###############
+    # Forecasting #
+    ###############
+    
+    x=Dense(units = 45, activation = 'relu')(encoded)
+    forecast = Dense(units = 45, activation = 'relu')(x)
+    
+    
+
+    ############
+    # Decoding #
+    ############
+
+    # DeConv1
+    x = Conv2D(8, (3, 3), activation='relu', padding='same')(forecast)
+    x = UpSampling2D((2, 2))(x)
+
+    # DeConv2
+    x = Conv2D(8, (3, 3), activation='relu', padding='same')(x)
+    x = UpSampling2D((2, 2))(x)
+
+    # Deconv3
+    x = Conv2D(16, (3, 3), activation='relu', padding='same')(x)
+    x = UpSampling2D((2, 2))(x)
+    decoded = Conv2D(1, (3, 3), activation='sigmoid', padding='same')(x)
+    
+    return Model(input_img, decoded)


### PR DESCRIPTION
New features:
    - Get the (nearly) raw pixel data for a given area and timeframe
    - Convert that data into a very basic training set
    - Normalization for the dataset
    - Model based on an autoencoder for predictions of a day's precipitation based on the previous day's precipitation
    - Training the model a bit, but not much yet.  No way to check the model's results against a test set yet.
    - Created example of saving almost the whole CHIRTS dataset for Columbia into a local numpy file for quicker access
    
    Maintenance:
    - Moved some things around for better readability
    - Added some print statements in the function for reading EE data to numpy so you have an idea how far along it is.
    - Broke the main function out into discreet examples.  We should move these into their own files/functions

closes #3 